### PR TITLE
verify and mdsnippets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,6 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+
+*.verified.txt text eol=lf working-tree-encoding=UTF-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,10 @@ jobs:
       with:
         name: ${{ matrix.os }}-artifacts
         path: artifacts/
+    - name: Upload Test Results
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: verify-test-results
+        path: |
+          **/*.received.*

--- a/.github/workflows/on-push-do-docs.yml
+++ b/.github/workflows/on-push-do-docs.yml
@@ -1,0 +1,22 @@
+name: on-push-do-docs
+on:
+  push:
+jobs:
+  docs:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run MarkdownSnippets
+      run: |
+        dotnet tool install --global MarkdownSnippets.Tool
+        mdsnippets ${GITHUB_WORKSPACE}
+      shell: bash
+    - name: Push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "Docs changes" -a || echo "nothing to commit"
+        remote="https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+        branch="${GITHUB_REF:11}"
+        git push "${remote}" ${branch} || echo "nothing to push"
+      shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Rider
+.idea/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/NuGet.PackageLifeCycle.sln
+++ b/NuGet.PackageLifeCycle.sln
@@ -10,7 +10,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A6AD26CB-0E8C-498D-9EB4-3676E9FE39DD}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "src\Tests\Tests.csproj", "{4979990F-D43B-402A-9BBF-C2A95FE339FB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,12 +25,17 @@ Global
 		{5E220F24-EADB-4E9E-BB52-AA742E75A48B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E220F24-EADB-4E9E-BB52-AA742E75A48B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E220F24-EADB-4E9E-BB52-AA742E75A48B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4979990F-D43B-402A-9BBF-C2A95FE339FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4979990F-D43B-402A-9BBF-C2A95FE339FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4979990F-D43B-402A-9BBF-C2A95FE339FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4979990F-D43B-402A-9BBF-C2A95FE339FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{5E220F24-EADB-4E9E-BB52-AA742E75A48B} = {491D10D0-06BF-436E-9390-41A2C43606DD}
+		{4979990F-D43B-402A-9BBF-C2A95FE339FB} = {491D10D0-06BF-436E-9390-41A2C43606DD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A13EFED4-7DB8-4C76-B236-044C6FB5DC47}

--- a/README.md
+++ b/README.md
@@ -40,46 +40,22 @@ nuget-plc deprecate jQuery --all --legacy
 
 ### Help text
 
-```plaintext
+<!-- snippet: ProgramTests.Help.verified.txt -->
+<a id='snippet-ProgramTests.Help.verified.txt'></a>
+```txt
 Description:
-  Mark existing packages as deprecated.
+  A CLI tool to help you manage the lifecycle of published NuGet packages.
 
 Usage:
-  nuget-plc deprecate <PACKAGE_ID> [options]
-
-Arguments:
-  <PACKAGE_ID>  The ID of the package that should be deprecated.
+  nuget-plc [command] [options]
 
 Options:
-  --version <version>          A specific version to mark as deprecated (multiple allowed).
-  --range <range>              A range of versions to mark as deprecated (multiple allowed).
-  --all                        Deprecate all versions.
-  --api-key <api-key>          The API key to use when deprecating the package.
-  --legacy                     Mark the deprecated versions as legacy.
-  --critical-bugs              Mark the deprecated versions as having critical bugs.
-  --other-reason               Mark the deprecated versions as having some other deprecation
-                               reason. Enabled by default if no other deprecation reason is
-                               selected.
-  --message <message>          A deprecation message to display. Required if --other-reason is
-                               specified or no other deprecation reason is selected.
-  --alternate-id <id>          An alternate package ID to recommend instead of this package.
-  --alternate-version <ver>    A specific alternate package version to recommend. Only usable with
-                               --alternate-id.
-  --dry-run                    Runs the entire operation without actually submitting the
-                               deprecation request.
-  --overwrite                  Replace existing deprecation metadata on a package version.
-  --allow-missing-versions     Allow deprecating versions that are not yet available on the source.
-  --skip-validation            Skip as much validation as possible before submitting the request.
-  --source <source>            The package source to use. [default:
-                               https://api.nuget.org/v3/index.json]
-  --package-publish-url <url>  The URL to use for the PackagePublish resource. Defaults to
-                               discovering it from the --source option.
-  --listed                     Set the listed status of the versions while deprecating. Use 'false'
-                               to unlist the versions, 'true' to relist them. If the option is not
-                               provided, it defaults to not changing the listed status at all.
-  --confirm                    Interactively confirm the contents of the deprecation API request
-                               before proceeding.
-  --log-level <level>          The minimum log level to display. Possible values: Verbose, Debug,
-                               Information, Warning, Error, Fatal [default: Information]
-  -?, -h, --help               Show help and usage information
+  --log-level <level>  The minimum log level to display. Possible values: Verbose, Debug, Information, Warning, Error, Fatal [default: Information]
+  -?, -h, --help       Show help and usage information
+  --version            Show version information
+
+Commands:
+  deprecate <PACKAGE_ID>  Mark existing packages as deprecated.
 ```
+<sup><a href='/src/Tests/ProgramTests.Help.verified.txt#L1-L14' title='Snippet source file'>snippet source</a> | <a href='#snippet-ProgramTests.Help.verified.txt' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->

--- a/mdsnippets.json
+++ b/mdsnippets.json
@@ -1,0 +1,4 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/SimonCropp/MarkdownSnippets/master/schema.json",
+  "Convention": "InPlaceOverwrite"
+}

--- a/src/NuGet.PackageLifeCycle/AssemblyAttributes.cs
+++ b/src/NuGet.PackageLifeCycle/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tests")]

--- a/src/NuGet.PackageLifeCycle/AssemblyAttributes.cs
+++ b/src/NuGet.PackageLifeCycle/AssemblyAttributes.cs
@@ -1,3 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Tests")]

--- a/src/NuGet.PackageLifeCycle/NuGet.PackageLifeCycle.csproj
+++ b/src/NuGet.PackageLifeCycle/NuGet.PackageLifeCycle.csproj
@@ -3,8 +3,6 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	
 	<PropertyGroup>

--- a/src/NuGet.PackageLifeCycle/Program.cs
+++ b/src/NuGet.PackageLifeCycle/Program.cs
@@ -9,34 +9,40 @@ using System.CommandLine.Hosting;
 using System.CommandLine.Parsing;
 using System.Runtime.InteropServices;
 
-var builder = new UserAgentStringBuilder("NuGet.PackageLifeCycle")
-    .WithOSDescription(string.Join("; ", new object[]
-    {
-        RuntimeInformation.OSDescription,
-        RuntimeInformation.OSArchitecture,
-        RuntimeInformation.FrameworkDescription,
-        RuntimeInformation.RuntimeIdentifier,
-    }));
-UserAgent.SetUserAgentString(builder);
-
-var runner = new CommandLineBuilder(new PackageLifeCycleCommand())
-    .UseExceptionHandler()
-    .UseHost(_ => Host.CreateDefaultBuilder(args), (builder) => builder
-        .UseSerilog()
-        .ConfigureServices((hostContext, services) =>
-        {
-            services.AddTransient<DeprecationService>();
-            services.AddCustomSerilog();
-        })
-        .UseCommandHandler<DeprecateCommand, DeprecateCommand.Handler>())
-    .UseHelp()
-    .UseVersionOption()
-    .UseParseErrorReporting()
-    .Build();
-
-if (args.Length == 0 || args.All(string.IsNullOrWhiteSpace))
+public static class Program
 {
-    args = ["--help"];
-}
+    public static async Task<int> Main(string[] args)
+    {
+        var builder = new UserAgentStringBuilder("NuGet.PackageLifeCycle")
+            .WithOSDescription(string.Join("; ", new object[]
+            {
+                RuntimeInformation.OSDescription,
+                RuntimeInformation.OSArchitecture,
+                RuntimeInformation.FrameworkDescription,
+                RuntimeInformation.RuntimeIdentifier,
+            }));
+        UserAgent.SetUserAgentString(builder);
 
-return await runner.Parse(args).InvokeAsync();
+        var runner = new CommandLineBuilder(new PackageLifeCycleCommand())
+            .UseExceptionHandler()
+            .UseHost(_ => Host.CreateDefaultBuilder(args), (builder) => builder
+                .UseSerilog()
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient<DeprecationService>();
+                    services.AddCustomSerilog();
+                })
+                .UseCommandHandler<DeprecateCommand, DeprecateCommand.Handler>())
+            .UseHelp()
+            .UseVersionOption()
+            .UseParseErrorReporting()
+            .Build();
+
+        if (args.Length == 0 || args.All(string.IsNullOrWhiteSpace))
+        {
+            args = ["--help"];
+        }
+
+        return await runner.Parse(args).InvokeAsync();
+    }
+}

--- a/src/Tests/GlobalUsings.cs
+++ b/src/Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using System.Runtime.CompilerServices;

--- a/src/Tests/ModuleInitializer.cs
+++ b/src/Tests/ModuleInitializer.cs
@@ -1,0 +1,6 @@
+﻿public static class ModuleInitializer
+{
+    [ModuleInitializer]
+    public static void Init() =>
+        VerifierSettings.InitializePlugins();
+}

--- a/src/Tests/ProgramTests.Help.verified.txt
+++ b/src/Tests/ProgramTests.Help.verified.txt
@@ -1,0 +1,14 @@
+﻿Description:
+  A CLI tool to help you manage the lifecycle of published NuGet packages.
+
+Usage:
+  nuget-plc [command] [options]
+
+Options:
+  --log-level <level>  The minimum log level to display. Possible values: Verbose, Debug, Information, Warning, Error, Fatal [default: Information]
+  -?, -h, --help       Show help and usage information
+  --version            Show version information
+
+Commands:
+  deprecate <PACKAGE_ID>  Mark existing packages as deprecated.
+

--- a/src/Tests/ProgramTests.Help_deprecate.verified.txt
+++ b/src/Tests/ProgramTests.Help_deprecate.verified.txt
@@ -1,71 +1,4 @@
-# Knapcode.PackageLifeCycle (nuget-plc)
-
-A CLI tool to help you manage the lifecycle of published NuGet packages.
-
-Right now, all it does is deprecates packages using a preview "deprecate" API on NuGet.org.
-
-## Install
-
-```console
-dotnet tool install Knapcode.PackageLifeCycle --prerelease --global
-```
-
-This will install the `nuget-plc` command into your PATH.
-
-## Help text
-
-<!-- snippet: ProgramTests.Help.verified.txt -->
-<a id='snippet-ProgramTests.Help.verified.txt'></a>
-```txt
-Description:
-  A CLI tool to help you manage the lifecycle of published NuGet packages.
-
-Usage:
-  nuget-plc [command] [options]
-
-Options:
-  --log-level <level>  The minimum log level to display. Possible values: Verbose, Debug, Information, Warning, Error, Fatal [default: Information]
-  -?, -h, --help       Show help and usage information
-  --version            Show version information
-
-Commands:
-  deprecate <PACKAGE_ID>  Mark existing packages as deprecated.
-```
-<sup><a href='/src/Tests/ProgramTests.Help.verified.txt#L1-L14' title='Snippet source file'>snippet source</a> | <a href='#snippet-ProgramTests.Help.verified.txt' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-## Deprecate
-
-This command is used to mark packages as deprecated.
-
-### Example
-
-**Note:** The `--api-key` option is required when deprecating packages on NuGet.org.
-
-Mark a specific version as having critical bugs with a message.
-
-```console
-nuget-plc deprecate jQuery --version 3.5.0 --critical-bugs --message "Bad, bad bugs!"
-```
-
-Mark a specific range of versions as deprecated with an alternate.
-
-```console
-nuget-plc deprecate NuGet.Core --range "[, 3.0.0)" --alternate-id NuGet.Protocol --message "Use this other thing."
-```
-
-Mark all versions as legacy.
-
-```console
-nuget-plc deprecate jQuery --all --legacy
-```
-
-### Help text
-
-<!-- snippet: ProgramTests.Help_deprecate.verified.txt -->
-<a id='snippet-ProgramTests.Help_deprecate.verified.txt'></a>
-```txt
-Description:
+﻿Description:
   Mark existing packages as deprecated.
 
 Usage:
@@ -95,6 +28,6 @@ Options:
   --confirm                    Interactively confirm the contents of the deprecation API request before proceeding.
   --log-level <level>          The minimum log level to display. Possible values: Verbose, Debug, Information, Warning, Error, Fatal [default: Information]
   -?, -h, --help               Show help and usage information
-```
-<sup><a href='/src/Tests/ProgramTests.Help_deprecate.verified.txt#L1-L33' title='Snippet source file'>snippet source</a> | <a href='#snippet-ProgramTests.Help_deprecate.verified.txt' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
+
+
+

--- a/src/Tests/ProgramTests.cs
+++ b/src/Tests/ProgramTests.cs
@@ -1,13 +1,22 @@
-﻿[TestFixture]
+﻿using System.Text;
+
+[TestFixture]
 public class ProgramTests
 {
     [Test]
-    public async Task Help()
+    public Task Help() =>
+        Verify(RunProgram(["--help"]));
+
+    [Test]
+    public Task Help_deprecate() =>
+        Verify(RunProgram(["--help", "deprecate"]));
+
+    static async Task<StringBuilder> RunProgram(string[] args)
     {
         await using var writer = new StringWriter();
         Console.SetOut(writer);
         Console.SetError(writer);
-        await Program.Main(["--help"]);
-        await Verify(writer.GetStringBuilder());
+        await Program.Main(args);
+        return writer.GetStringBuilder();
     }
 }

--- a/src/Tests/ProgramTests.cs
+++ b/src/Tests/ProgramTests.cs
@@ -1,0 +1,13 @@
+﻿[TestFixture]
+public class ProgramTests
+{
+    [Test]
+    public async Task Help()
+    {
+        await using var writer = new StringWriter();
+        Console.SetOut(writer);
+        Console.SetError(writer);
+        await Program.Main(["--help"]);
+        await Verify(writer.GetStringBuilder());
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="MarkdownSnippets.MsBuild" Version="27.0.2" PrivateAssets="all" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Verify.DiffPlex" Version="3.0.0" />
+    <PackageReference Include="Verify.NUnit" Version="24.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <ProjectReference Include="..\NuGet.PackageLifeCycle\NuGet.PackageLifeCycle.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
re https://github.com/SimonCropp/MarkdownSnippets/issues/710

this PR represents how i would solve the problem.

So in effect this PR does

 * use Verify to assert the output of the program.
 * as a side effect we now have the output of a given console args in a snapshot file
 * use that snapshot file as a snippet.

so this way when you change the output, you get to QA th output before accepting it. and the readme will be updated on the next build. The "updated on the next build" can be annoying if u forget to do a build before pushing a change. so i have added a GH action that will re run the docs to ensure they are always in sync.

List of all changes:

 * pulled out common settings into a Directory.Build.props
 * added a test project. i picked nunit. let me know if u want mstest or xunit
 * added verify to that project.
 * added tests for help and deprecate as mentioned above
 * added an Upload Test Results step to the GH build. so that if Verify detects a mis-match in CI you will get the resulting files as assets. saves you trolling through the build log for the differences
 * added a on-push-do-docs.yml action. as mentioned above
 * ignore `.idea/` since i like rider ;)
 * added an mdsnippets config file with InPlaceOverwrite https://github.com/SimonCropp/MarkdownSnippets?tab=readme-ov-file#inplaceoverwrite That is usually the preferred option for smaller projects
 * Moved to a non top level statement. so we can call it from a test


